### PR TITLE
use built-in array observation

### DIFF
--- a/Source/DriveAgentsCPP/LearningAgents/AutonomousVehicleInteractor.h
+++ b/Source/DriveAgentsCPP/LearningAgents/AutonomousVehicleInteractor.h
@@ -4,6 +4,7 @@
 
 #include "CoreMinimal.h"
 #include "LearningAgentsInteractor.h"
+#include "LearningAgentsObservations.h"
 #include "AutonomousVehicleInteractor.generated.h"
 
 // Learning agents and components forward declarations

--- a/Source/DriveAgentsCPP/LearningAgents/AutonomousVehicleInteractor.h
+++ b/Source/DriveAgentsCPP/LearningAgents/AutonomousVehicleInteractor.h
@@ -47,8 +47,8 @@ protected:
 	UPlanarPositionObservation* TrackPositionObservation;
 	UPlanarDirectionObservation* TrackDirectionObservation;
 
-	UPlanarPositionObservation** TrackLookAheadPositionObservations;
-	UPlanarDirectionObservation** TrackLookAheadDirectionObservations;
+	UPlanarPositionArrayObservation* TrackLookAheadPositionArrayObservations;
+	UPlanarDirectionArrayObservation* TrackLookAheadDirectionArrayObservations;
 
 	UAngleObservation* TrackPositionParameterObservation;
 	UPlanarVelocityObservation* CarVelocityObservation;


### PR DESCRIPTION
Use `TrackLookAheadPositionArrayObservations` & `TrackLookAheadDirectionArrayObservations` instead of `TrackLookAheadPositionObservations` & `TrackLookAheadDirectionObservations`.

First, it was to avoid a memory leak, but then I read somewhere that there's a GC in Unreal Engine. So I don't know if this change is really relevant.

(A full retrain of `RL_NeuralNet-LookAhead.uasset` is required)